### PR TITLE
DataExporter: DataExporter to support Other Data Components #4414

### DIFF
--- a/src/main/java/org/primefaces/showcase/view/data/dataexporter/DataExporterView.java
+++ b/src/main/java/org/primefaces/showcase/view/data/dataexporter/DataExporterView.java
@@ -15,21 +15,26 @@
  */
 package org.primefaces.showcase.view.data.dataexporter;
 
-import org.primefaces.showcase.domain.Car;
-import org.primefaces.showcase.service.CarService;
+import java.io.Serializable;
+import java.util.List;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
-import java.io.Serializable;
-import java.util.List;
+
+import org.primefaces.component.datatable.DataTable;
+import org.primefaces.component.export.Exporter;
+import org.primefaces.showcase.domain.Car;
+import org.primefaces.showcase.service.CarService;
 
 @Named
 @RequestScoped
 public class DataExporterView implements Serializable {
     
     private List<Car> cars;
+    
+    private Exporter<DataTable> textExporter;
         
     @Inject
     private CarService service;
@@ -37,6 +42,7 @@ public class DataExporterView implements Serializable {
     @PostConstruct
     public void init() {
         cars = service.createCars(100);
+        textExporter = new TextExporter();
     }
 
     public List<Car> getCars() {
@@ -46,4 +52,14 @@ public class DataExporterView implements Serializable {
     public void setService(CarService service) {
         this.service = service;
     }
+
+    public Exporter<DataTable> getTextExporter() {
+        return textExporter;
+    }
+
+    public void setTextExporter(Exporter<DataTable> textExporter) {
+        this.textExporter = textExporter;
+    }
+    
+    
 }

--- a/src/main/java/org/primefaces/showcase/view/data/dataexporter/TextExporter.java
+++ b/src/main/java/org/primefaces/showcase/view/data/dataexporter/TextExporter.java
@@ -1,0 +1,161 @@
+package org.primefaces.showcase.view.data.dataexporter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.util.Collections;
+import java.util.List;
+
+import javax.el.MethodExpression;
+import javax.faces.FacesException;
+import javax.faces.component.UIComponent;
+import javax.faces.context.ExternalContext;
+import javax.faces.context.FacesContext;
+
+import org.primefaces.component.api.DynamicColumn;
+import org.primefaces.component.api.UIColumn;
+import org.primefaces.component.datatable.DataTable;
+import org.primefaces.component.datatable.export.DataTableExporter;
+import org.primefaces.component.export.ExporterOptions;
+import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.Constants;
+import org.primefaces.util.EscapeUtils;
+
+public class TextExporter extends DataTableExporter {
+    @Override
+    public void export(FacesContext context, DataTable table, String filename, boolean pageOnly, boolean selectionOnly,
+                       String encodingType, MethodExpression preProcessor, MethodExpression postProcessor, ExporterOptions options,
+                       MethodExpression onTableRender) throws IOException {
+
+        ExternalContext externalContext = context.getExternalContext();
+        configureResponse(externalContext, filename);
+        StringBuilder builder = new StringBuilder();
+
+        if (preProcessor != null) {
+            preProcessor.invoke(context.getELContext(), new Object[]{builder});
+        }
+
+        builder.append("" + table.getId() + "\n");
+
+        if (pageOnly) {
+            exportPageOnly(context, table, builder);
+        }
+        else if (selectionOnly) {
+            exportSelectionOnly(context, table, builder);
+        }
+        else {
+            exportAll(context, table, builder);
+        }
+
+        builder.append("" + table.getId() + "");
+
+        table.setRowIndex(-1);
+
+        if (postProcessor != null) {
+            postProcessor.invoke(context.getELContext(), new Object[]{builder});
+        }
+
+        OutputStream os = externalContext.getResponseOutputStream();
+        OutputStreamWriter osw = new OutputStreamWriter(os, encodingType);
+        PrintWriter writer = new PrintWriter(osw);
+        writer.write(builder.toString());
+        writer.flush();
+        writer.close();
+    }
+
+    @Override
+    public void export(FacesContext facesContext, List<String> clientIds, String outputFileName, boolean pageOnly, boolean selectionOnly,
+                       String encodingType, MethodExpression preProcessor, MethodExpression postProcessor, ExporterOptions options,
+                       MethodExpression onTableRender) throws IOException {
+
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void export(FacesContext facesContext, String outputFileName, List<DataTable> tables, boolean pageOnly, boolean selectionOnly,
+                       String encodingType, MethodExpression preProcessor, MethodExpression postProcessor, ExporterOptions options,
+                       MethodExpression onTableRender) throws IOException {
+
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    protected void preRowExport(DataTable table, Object document) {
+        ((StringBuilder) document).append("\t" + table.getVar() + "\n");
+    }
+
+    @Override
+    protected void postRowExport(DataTable table, Object document) {
+        ((StringBuilder) document).append("\t" + table.getVar() + "\n");
+    }
+
+    @Override
+    protected void exportCells(DataTable table, Object document) {
+        StringBuilder builder = (StringBuilder) document;
+        for (UIColumn col : table.getColumns()) {
+            if (col instanceof DynamicColumn) {
+                ((DynamicColumn) col).applyStatelessModel();
+            }
+
+            if (col.isRendered() && col.isExportable()) {
+                String columnTag = getColumnTag(col);
+                try {
+                    addColumnValue(builder, col.getChildren(), columnTag, col);
+                }
+                catch (IOException ex) {
+                    throw new FacesException(ex);
+                }
+            }
+        }
+    }
+
+    protected String getColumnTag(UIColumn column) {
+        String headerText = (column.getExportHeaderValue() != null) ? column.getExportHeaderValue() : column.getHeaderText();
+        UIComponent facet = column.getFacet("header");
+        String columnTag;
+
+        if (headerText != null) {
+            columnTag = headerText.toLowerCase();
+        }
+        else if (facet != null) {
+            columnTag = exportValue(FacesContext.getCurrentInstance(), facet).toLowerCase();
+        }
+        else {
+            throw new FacesException("No suitable xml tag found for " + column);
+        }
+
+        return EscapeUtils.forXmlTag(columnTag);
+    }
+
+    protected void addColumnValue(StringBuilder builder, List<UIComponent> components, String tag, UIColumn column) throws IOException {
+        FacesContext context = FacesContext.getCurrentInstance();
+
+        builder.append("\t\t" + tag + "");
+
+        if (column.getExportFunction() != null) {
+            builder.append(EscapeUtils.forXml(exportColumnByFunction(context, column)));
+        }
+        else {
+            for (UIComponent component : components) {
+                if (component.isRendered()) {
+                    String value = exportValue(context, component);
+                    if (value != null) {
+                        builder.append(EscapeUtils.forXml(value));
+                    }
+                }
+            }
+        }
+
+        builder.append("" + tag + "\n");
+    }
+
+    protected void configureResponse(ExternalContext externalContext, String filename) {
+        externalContext.setResponseContentType("text/plain");
+        externalContext.setResponseHeader("Expires", "0");
+        externalContext.setResponseHeader("Cache-Control", "must-revalidate, post-check=0, pre-check=0");
+        externalContext.setResponseHeader("Pragma", "public");
+        externalContext.setResponseHeader("Content-disposition", ComponentUtils.createContentDisposition("attachment", filename + ".txt"));
+        externalContext.addResponseCookie(Constants.DOWNLOAD_COOKIE, "true", Collections.<String, Object>emptyMap());
+    }
+}

--- a/src/main/webapp/ui/data/dataexporter/basic.xhtml
+++ b/src/main/webapp/ui/data/dataexporter/basic.xhtml
@@ -52,10 +52,9 @@
                         </h:commandLink>
                         
                         <h:commandLink>
-							<p:graphicImage name="/demo/images/metroui.png" width="24" />
-							<p:dataExporter type="text" target="tbl" fileName="cars"
-								customExporter="#{dataExporterView.textExporter}" />
-						</h:commandLink>
+                            <p:graphicImage name="/demo/images/metroui.png" width="24"/>
+                            <p:dataExporter type="text" target="tbl" fileName="cars" customExporter="#{dataExporterView.textExporter}"/>
+                        </h:commandLink>                        
                     </div>
                 </f:facet>
 

--- a/src/main/webapp/ui/data/dataexporter/basic.xhtml
+++ b/src/main/webapp/ui/data/dataexporter/basic.xhtml
@@ -50,6 +50,12 @@
                             <p:graphicImage name="/demo/images/xml.png" width="24"/>
                             <p:dataExporter type="xml" target="tbl" fileName="cars" />
                         </h:commandLink>
+                        
+                        <h:commandLink>
+							<p:graphicImage name="/demo/images/metroui.png" width="24" />
+							<p:dataExporter type="text" target="tbl" fileName="cars"
+								customExporter="#{dataExporterView.textExporter}" />
+						</h:commandLink>
                     </div>
                 </f:facet>
 


### PR DESCRIPTION
Sample for a Text Export

https://primefaces.github.io/primefaces/7_0/#/components/dataexporter
customExporter  org.primefaces.component.export.Exporter to be used in place of default Exporter.


