### PR TITLE
new progressBar usage added with progress updated out of getProgress method

### DIFF
--- a/src/main/java/org/primefaces/showcase/view/misc/ProgressBarView.java
+++ b/src/main/java/org/primefaces/showcase/view/misc/ProgressBarView.java
@@ -26,31 +26,55 @@ import java.io.Serializable;
 @ViewScoped
 public class ProgressBarView implements Serializable {
     
-    private Integer progress;
+    private Integer progress1;
+    private Integer progress2;
 
-	public Integer getProgress() {
-		if(progress == null) {
-			progress = 0;
+    public Integer getProgress1() {
+        progress1 = updateProgress(progress1);
+        return progress1;
+    }
+
+    public Integer getProgress2() {
+        progress2 = updateProgress(progress2);
+        return progress2;
+    }
+
+    public void longRunning() throws InterruptedException {
+        progress2 = 0;
+        while (progress2 == null || progress2 < 100) {
+            progress2 = updateProgress(progress2);
+            Thread.sleep(500);
         }
-		else {
-			progress = progress + (int)(Math.random() * 35);
-			
-			if(progress > 100)
-				progress = 100;
-		}
-		
-		return progress;
-	}
+    }
 
-	public void setProgress(Integer progress) {
-		this.progress = progress;
-	}
-	
-	public void onComplete() {
-		FacesContext.getCurrentInstance().addMessage(null, new FacesMessage("Progress Completed"));
-	}
-    
+    private Integer updateProgress(Integer progress) {
+        if(progress == null) {
+            progress = 0;
+        }
+        else {
+            progress = progress + (int)(Math.random() * 35);
+            
+            if(progress > 100)
+                progress = 100;
+        }
+        
+        return progress;
+    }
+
+    public void setProgress1(Integer progress1) {
+        this.progress1 = progress1;
+    }
+
+    public void setProgress2(Integer progress2) {
+        this.progress2 = progress2;
+    }
+
+    public void onComplete() {
+        FacesContext.getCurrentInstance().addMessage(null, new FacesMessage("Progress Completed"));
+    }
+
     public void cancel() {
-        progress = null;
+        progress1 = null;
+        progress2 = null;
     }
 }

--- a/src/main/webapp/ui/misc/exceptionHandler.xhtml
+++ b/src/main/webapp/ui/misc/exceptionHandler.xhtml
@@ -27,6 +27,7 @@
             <p:commandButton action="#{exceptionHandlerView.throwNullPointerException}"
                              ajax="true"
                              value="Throw NullPointerException!" />
+            <!-- IllegalStateException is not handled using ajaxExceptionHandlers below, so the error page is shown-->
             <p:commandButton action="#{exceptionHandlerView.throwWrappedIllegalStateException}"
                              ajax="true"
                              value="Throw IllegalStateException!" />
@@ -35,6 +36,8 @@
             <p:commandButton action="#{exceptionHandlerView.throwViewExpiredException}"
                              ajax="false"
                              value="Throw ViewExpiredException!" />
+            <!-- NullPointerException has no specific error-page defined in web.xml compared to ViewExpiredException -->
+            <!-- https://github.com/primefaces/showcase-facelift/blob/master/src/main/webapp/WEB-INF/web.xml -->
             <p:commandButton action="#{exceptionHandlerView.throwNullPointerException}"
                              ajax="false"
                              value="Throw NullPointerException!" />

--- a/src/main/webapp/ui/misc/progressBar.xhtml
+++ b/src/main/webapp/ui/misc/progressBar.xhtml
@@ -66,8 +66,16 @@ function cancel() {
             <p:commandButton value="Start" type="button" onclick="PF('pbAjax').start();PF('startButton2').disable();" widgetVar="startButton2" />
             <p:commandButton value="Cancel" action="#{progressBarView.cancel}" oncomplete="PF('pbAjax').cancel();PF('startButton2').enable();" />
             <br /><br />
-            <p:progressBar widgetVar="pbAjax" ajax="true" value="#{progressBarView.progress}" labelTemplate="{value}%" styleClass="animated" global="false">
+            <p:progressBar widgetVar="pbAjax" ajax="true" value="#{progressBarView.progress1}" labelTemplate="{value}%" styleClass="animated" global="false">
                 <p:ajax event="complete" listener="#{progressBarView.onComplete}" update="growl" oncomplete="PF('startButton2').enable()"/>
+            </p:progressBar>
+
+            <h3>Ajax ProgressBar (with long running method)</h3>
+            <p:commandButton value="Start" type="button" onclick="PF('pbAjaxLong').start();PF('startButton3').disable();" widgetVar="startButton3" actionListener="#{progressBarView.longRunning}"/>
+            <p:commandButton value="Cancel" action="#{progressBarView.cancel}" oncomplete="PF('pbAjaxLong').cancel();PF('startButton3').enable();" />
+            <br /><br />
+            <p:progressBar widgetVar="pbAjaxLong" ajax="true" value="#{progressBarView.progress2}" labelTemplate="{value}%" styleClass="animated" global="false" interval="500">
+                <p:ajax event="complete" listener="#{progressBarView.onComplete}" update="growl" oncomplete="PF('startButton3').enable()"/>
             </p:progressBar>
 
             <h3>Static Display</h3>


### PR DESCRIPTION
The original example was updating the progress in getProgress() what I believe is not typical usage.

I extended progressBar.xhtml with new progressBar (`pbAjaxLong`), that is executing `longRunning()` from bean and is just reading the progress in `getProgress2()`.